### PR TITLE
Add spatial distance plugin

### DIFF
--- a/SOFAR/SOFAR.jucer
+++ b/SOFAR/SOFAR.jucer
@@ -11,6 +11,8 @@
       <FILE id="kC4GUp" name="PluginEditor.cpp" compile="1" resource="0"
             file="Source/PluginEditor.cpp"/>
       <FILE id="U337K9" name="PluginEditor.h" compile="0" resource="0" file="Source/PluginEditor.h"/>
+      <FILE id="IRDAT" name="IRData.h" compile="0" resource="0" file="Source/IRData.h"/>
+      <FILE id="SCONV" name="SimpleConvolution.h" compile="0" resource="0" file="Source/SimpleConvolution.h"/>
     </GROUP>
   </MAINGROUP>
   <MODULES>

--- a/SOFAR/Source/IRData.h
+++ b/SOFAR/Source/IRData.h
@@ -1,0 +1,34 @@
+#ifndef IR_DATA_H
+#define IR_DATA_H
+
+#include <vector>
+#include <JuceHeader.h>
+
+inline std::vector<float> getIR(int index)
+{
+    constexpr int len = 256;
+    static std::vector<float> irA(len), irB(len), irC(len), irD(len);
+    static bool initialised = false;
+    if (!initialised)
+    {
+        for (int i = 0; i < len; ++i)
+        {
+            float t = (float)i / (float)len;
+            irA[i] = std::exp(-6.0f * t);
+            irB[i] = std::exp(-4.0f * t) * std::sin(juce::MathConstants<float>::twoPi * 0.1f * i);
+            irC[i] = std::exp(-8.0f * t) * (0.5f - 0.5f * std::cos(juce::MathConstants<float>::twoPi * i / len));
+            irD[i] = std::exp(-3.0f * t);
+        }
+        initialised = true;
+    }
+
+    switch (index)
+    {
+        case 0:  return irA;
+        case 1:  return irB;
+        case 2:  return irC;
+        default: return irD;
+    }
+}
+
+#endif // IR_DATA_H

--- a/SOFAR/Source/PluginEditor.cpp
+++ b/SOFAR/Source/PluginEditor.cpp
@@ -13,9 +13,21 @@
 SOFARAudioProcessorEditor::SOFARAudioProcessorEditor (SOFARAudioProcessor& p)
     : AudioProcessorEditor (&p), audioProcessor (p)
 {
-    // Make sure that before the constructor has finished, you've set the
-    // editor's size to whatever you need it to be.
-    setSize (400, 300);
+    setSize (400, 200);
+
+    distanceSlider.setSliderStyle (juce::Slider::Rotary);
+    distanceSlider.setTextBoxStyle (juce::Slider::TextBoxBelow, false, 60, 20);
+    addAndMakeVisible (distanceSlider);
+
+    distanceLabel.setText ("Distance", juce::dontSendNotification);
+    distanceLabel.attachToComponent (&distanceSlider, false);
+
+    distanceAttachment.reset (new juce::AudioProcessorValueTreeState::SliderAttachment(audioProcessor.parameters, "distance", distanceSlider));
+
+    attachButton (buttonA, 0);
+    attachButton (buttonB, 1);
+    attachButton (buttonC, 2);
+    attachButton (buttonD, 3);
 }
 
 SOFARAudioProcessorEditor::~SOFARAudioProcessorEditor()
@@ -25,16 +37,26 @@ SOFARAudioProcessorEditor::~SOFARAudioProcessorEditor()
 //==============================================================================
 void SOFARAudioProcessorEditor::paint (juce::Graphics& g)
 {
-    // (Our component is opaque, so we must completely fill the background with a solid colour)
-    g.fillAll (getLookAndFeel().findColour (juce::ResizableWindow::backgroundColourId));
-
-    g.setColour (juce::Colours::white);
-    g.setFont (juce::FontOptions (15.0f));
-    g.drawFittedText ("Hello World!", getLocalBounds(), juce::Justification::centred, 1);
+    g.fillAll (juce::Colours::black);
 }
 
 void SOFARAudioProcessorEditor::resized()
 {
-    // This is generally where you'll want to lay out the positions of any
-    // subcomponents in your editor..
+    auto area = getLocalBounds().reduced (20);
+    distanceSlider.setBounds (area.removeFromLeft (120));
+    auto buttonArea = area.removeFromTop (30);
+    buttonA.setBounds (buttonArea.removeFromLeft (40));
+    buttonB.setBounds (buttonArea.removeFromLeft (40));
+    buttonC.setBounds (buttonArea.removeFromLeft (40));
+    buttonD.setBounds (buttonArea.removeFromLeft (40));
+}
+
+void SOFARAudioProcessorEditor::attachButton(juce::TextButton& button, int index)
+{
+    addAndMakeVisible (button);
+    button.onClick = [this, index]
+    {
+        audioProcessor.parameters.getParameter("space")->setValueNotifyingHost ((float) index / 3.0f);
+        audioProcessor.updateIR();
+    };
 }

--- a/SOFAR/Source/PluginEditor.h
+++ b/SOFAR/Source/PluginEditor.h
@@ -28,6 +28,14 @@ private:
     // This reference is provided as a quick way for your editor to
     // access the processor object that created it.
     SOFARAudioProcessor& audioProcessor;
+    juce::Slider distanceSlider;
+    juce::Label distanceLabel;
+    juce::TextButton buttonA { "A" };
+    juce::TextButton buttonB { "B" };
+    juce::TextButton buttonC { "C" };
+    juce::TextButton buttonD { "D" };
+    std::unique_ptr<juce::AudioProcessorValueTreeState::SliderAttachment> distanceAttachment;
+    void attachButton(juce::TextButton& button, int index);
 
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (SOFARAudioProcessorEditor)
 };

--- a/SOFAR/Source/PluginProcessor.cpp
+++ b/SOFAR/Source/PluginProcessor.cpp
@@ -19,13 +19,24 @@ SOFARAudioProcessor::SOFARAudioProcessor()
                       #endif
                        .withOutput ("Output", juce::AudioChannelSet::stereo(), true)
                      #endif
-                       )
+                       ),
+       parameters (*this, nullptr, "PARAMS", createParameters())
 #endif
 {
+    updateIR();
 }
 
 SOFARAudioProcessor::~SOFARAudioProcessor()
 {
+}
+
+juce::AudioProcessorValueTreeState::ParameterLayout SOFARAudioProcessor::createParameters()
+{
+    std::vector<std::unique_ptr<juce::RangedAudioParameter>> params;
+    params.push_back (std::make_unique<juce::AudioParameterFloat> ("distance", "Distance", 0.0f, 1.0f, 0.0f));
+    juce::StringArray choices { "A", "B", "C", "D" };
+    params.push_back (std::make_unique<juce::AudioParameterChoice> ("space", "Space", choices, 0));
+    return { params.begin(), params.end() };
 }
 
 //==============================================================================
@@ -93,14 +104,13 @@ void SOFARAudioProcessor::changeProgramName (int index, const juce::String& newN
 //==============================================================================
 void SOFARAudioProcessor::prepareToPlay (double sampleRate, int samplesPerBlock)
 {
-    // Use this method as the place to do any pre-playback
-    // initialisation that you need..
+    convolution.prepare(getTotalNumInputChannels());
+    updateIR();
 }
 
 void SOFARAudioProcessor::releaseResources()
 {
-    // When playback stops, you can use this as an opportunity to free up any
-    // spare memory, etc.
+    currentIR.clear();
 }
 
 #ifndef JucePlugin_PreferredChannelConfigurations
@@ -135,26 +145,28 @@ void SOFARAudioProcessor::processBlock (juce::AudioBuffer<float>& buffer, juce::
     auto totalNumInputChannels  = getTotalNumInputChannels();
     auto totalNumOutputChannels = getTotalNumOutputChannels();
 
-    // In case we have more outputs than inputs, this code clears any output
-    // channels that didn't contain input data, (because these aren't
-    // guaranteed to be empty - they may contain garbage).
-    // This is here to avoid people getting screaming feedback
-    // when they first compile a plugin, but obviously you don't need to keep
-    // this code if your algorithm always overwrites all the output channels.
     for (auto i = totalNumInputChannels; i < totalNumOutputChannels; ++i)
         buffer.clear (i, 0, buffer.getNumSamples());
 
-    // This is the place where you'd normally do the guts of your plugin's
-    // audio processing...
-    // Make sure to reset the state if your inner loop is processing
-    // the samples and the outer loop is handling the channels.
-    // Alternatively, you can process the samples with the channels
-    // interleaved by keeping the same state.
-    for (int channel = 0; channel < totalNumInputChannels; ++channel)
-    {
-        auto* channelData = buffer.getWritePointer (channel);
+    auto distance = parameters.getRawParameterValue("distance")->load();
+    auto space    = (int) parameters.getRawParameterValue("space")->load();
 
-        // ..do something to the data...
+    if (space != currentIndex)
+        updateIR();
+
+    juce::AudioBuffer<float> wetBuffer;
+    wetBuffer.makeCopyOf (buffer);
+    convolution.process (wetBuffer);
+
+    float dryGain = 1.0f - distance;
+    float wetGain = distance;
+
+    for (int ch = 0; ch < totalNumInputChannels; ++ch)
+    {
+        auto* dry  = buffer.getWritePointer (ch);
+        auto* wet  = wetBuffer.getReadPointer (ch);
+        for (int i = 0; i < buffer.getNumSamples(); ++i)
+            dry[i] = dry[i] * dryGain + wet[i] * wetGain;
     }
 }
 
@@ -172,15 +184,18 @@ juce::AudioProcessorEditor* SOFARAudioProcessor::createEditor()
 //==============================================================================
 void SOFARAudioProcessor::getStateInformation (juce::MemoryBlock& destData)
 {
-    // You should use this method to store your parameters in the memory block.
-    // You could do that either as raw data, or use the XML or ValueTree classes
-    // as intermediaries to make it easy to save and load complex data.
+    auto state = parameters.copyState();
+    std::unique_ptr<juce::XmlElement> xml (state.createXml());
+    copyXmlToBinary (*xml, destData);
 }
 
 void SOFARAudioProcessor::setStateInformation (const void* data, int sizeInBytes)
 {
-    // You should use this method to restore your parameters from this memory block,
-    // whose contents will have been created by the getStateInformation() call.
+    std::unique_ptr<juce::XmlElement> xmlState (getXmlFromBinary (data, sizeInBytes));
+    if (xmlState.get() != nullptr)
+        if (xmlState->hasTagName (parameters.state.getType()))
+            parameters.replaceState (juce::ValueTree::fromXml (*xmlState));
+    updateIR();
 }
 
 //==============================================================================
@@ -188,4 +203,16 @@ void SOFARAudioProcessor::setStateInformation (const void* data, int sizeInBytes
 juce::AudioProcessor* JUCE_CALLTYPE createPluginFilter()
 {
     return new SOFARAudioProcessor();
+}
+
+void SOFARAudioProcessor::updateIR()
+{
+    int index = (int) parameters.getRawParameterValue("space")->load();
+    if (index != currentIndex)
+    {
+        currentIR = getIR(index);
+        convolution.loadImpulse(currentIR);
+        convolution.prepare(getTotalNumInputChannels());
+        currentIndex = index;
+    }
 }

--- a/SOFAR/Source/PluginProcessor.h
+++ b/SOFAR/Source/PluginProcessor.h
@@ -13,6 +13,9 @@
 //==============================================================================
 /**
 */
+#include "SimpleConvolution.h"
+#include "IRData.h"
+
 class SOFARAudioProcessor  : public juce::AudioProcessor
 {
 public:
@@ -52,6 +55,15 @@ public:
     //==============================================================================
     void getStateInformation (juce::MemoryBlock& destData) override;
     void setStateInformation (const void* data, int sizeInBytes) override;
+
+    juce::AudioProcessorValueTreeState parameters;
+    static juce::AudioProcessorValueTreeState::ParameterLayout createParameters();
+
+    std::vector<float> currentIR;
+    int currentIndex = -1;
+    SimpleConvolution convolution;
+
+    void updateIR();
 
 private:
     //==============================================================================

--- a/SOFAR/Source/SimpleConvolution.h
+++ b/SOFAR/Source/SimpleConvolution.h
@@ -1,0 +1,53 @@
+#ifndef SIMPLE_CONVOLUTION_H
+#define SIMPLE_CONVOLUTION_H
+
+#include <vector>
+#include <algorithm>
+#include <cmath>
+#include <JuceHeader.h>
+
+class SimpleConvolution
+{
+public:
+    void loadImpulse(const std::vector<float>& newIR)
+    {
+        ir = newIR;
+        buffers.clear();
+    }
+
+    void prepare(int channels)
+    {
+        buffers.resize(channels);
+        for (auto& buf : buffers)
+            buf.assign(ir.size(), 0.0f);
+    }
+
+    void process(juce::AudioBuffer<float>& buffer)
+    {
+        auto numChannels = buffer.getNumChannels();
+        auto numSamples  = buffer.getNumSamples();
+        for (int ch = 0; ch < numChannels; ++ch)
+        {
+            auto* data = buffer.getWritePointer(ch);
+            auto& state = buffers[ch];
+            for (int i = 0; i < numSamples; ++i)
+            {
+                auto in = data[i];
+                state.insert(state.begin(), in);
+                if (state.size() > ir.size())
+                    state.pop_back();
+
+                float out = 0.0f;
+                for (size_t n = 0; n < ir.size(); ++n)
+                    out += state[n] * ir[n];
+                data[i] = out;
+            }
+        }
+    }
+
+private:
+    std::vector<float> ir;
+    std::vector<std::vector<float>> buffers;
+};
+
+#endif // SIMPLE_CONVOLUTION_H


### PR DESCRIPTION
## Summary
- implement a simple convolution engine and example impulse responses
- expose plugin parameters for distance amount and reverb type
- load IRs and crossfade dry/wet signal depending on knob
- design editor with one knob and A/B/C/D buttons

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683fc0fb8974832cabcec461880b4981